### PR TITLE
Switch hello world between iPhone and watch reachability

### DIFF
--- a/hearhear Watch App/ContentView.swift
+++ b/hearhear Watch App/ContentView.swift
@@ -1,19 +1,18 @@
-//
-//  ContentView.swift
-//  hearhear Watch App
-//
-//  Created by Erin Akarice on 9/16/25.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var reachability = PhoneReachabilityViewModel()
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        VStack(spacing: 12) {
+            if reachability.isPhoneReachable {
+                Text("iPhone is showing the greeting.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("Hello, world!")
+                    .font(.title3)
+            }
         }
         .padding()
     }

--- a/hearhear Watch App/PhoneReachabilityViewModel.swift
+++ b/hearhear Watch App/PhoneReachabilityViewModel.swift
@@ -1,0 +1,29 @@
+import Foundation
+import WatchConnectivity
+
+final class PhoneReachabilityViewModel: NSObject, ObservableObject {
+    @Published var isPhoneReachable: Bool = false
+
+    private let session: WCSession? = WCSession.isSupported() ? WCSession.default : nil
+
+    override init() {
+        super.init()
+        session?.delegate = self
+        session?.activate()
+        isPhoneReachable = session?.isReachable ?? false
+    }
+}
+
+extension PhoneReachabilityViewModel: WCSessionDelegate {
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        DispatchQueue.main.async {
+            self.isPhoneReachable = session.isReachable
+        }
+    }
+
+    func sessionReachabilityDidChange(_ session: WCSession) {
+        DispatchQueue.main.async {
+            self.isPhoneReachable = session.isReachable
+        }
+    }
+}

--- a/hearhear/ContentView.swift
+++ b/hearhear/ContentView.swift
@@ -1,19 +1,22 @@
-//
-//  ContentView.swift
-//  hearhear
-//
-//  Created by Erin Akarice on 9/16/25.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var reachability = WatchReachabilityViewModel()
+
     var body: some View {
-        VStack {
+        VStack(spacing: 16) {
             Image(systemName: "globe")
                 .imageScale(.large)
                 .foregroundStyle(.tint)
-            Text("Hello, world!")
+
+            if reachability.isWatchReachable {
+                Text("Hello, world!")
+                    .font(.title2)
+            } else {
+                Text("Look at your Apple Watch for the greeting.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
         }
         .padding()
     }

--- a/hearhear/WatchReachabilityViewModel.swift
+++ b/hearhear/WatchReachabilityViewModel.swift
@@ -1,0 +1,35 @@
+import Foundation
+import WatchConnectivity
+
+final class WatchReachabilityViewModel: NSObject, ObservableObject {
+    @Published var isWatchReachable: Bool = false
+
+    private let session: WCSession? = WCSession.isSupported() ? WCSession.default : nil
+
+    override init() {
+        super.init()
+        session?.delegate = self
+        session?.activate()
+        isWatchReachable = session?.isReachable ?? false
+    }
+}
+
+extension WatchReachabilityViewModel: WCSessionDelegate {
+    func sessionDidBecomeInactive(_ session: WCSession) {}
+
+    func sessionDidDeactivate(_ session: WCSession) {
+        session.activate()
+    }
+
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        DispatchQueue.main.async {
+            self.isWatchReachable = session.isReachable
+        }
+    }
+
+    func sessionReachabilityDidChange(_ session: WCSession) {
+        DispatchQueue.main.async {
+            self.isWatchReachable = session.isReachable
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create reachability view models on iPhone and Apple Watch to monitor the counterpart device
- update the iPhone view to show the greeting only when the watch is reachable
- update the watch view to present the greeting when the phone is unreachable

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68c964cef3148325bdfeb475a2b2c869