### PR TITLE
Implement cross-device greeting display coordination

### DIFF
--- a/hearhear Watch App/ContentView.swift
+++ b/hearhear Watch App/ContentView.swift
@@ -8,14 +8,25 @@
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var coordinator = DisplayCoordinator(localDevice: .watch)
+    @Environment(\.scenePhase) private var scenePhase
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        VStack(spacing: 12) {
+            if coordinator.showMessage {
+                Text("Hello, world!")
+                    .font(.headline)
+            } else if coordinator.activeDevice == .phone {
+                Text("Check your iPhone for \"Hello, world.\"")
+                    .multilineTextAlignment(.center)
+            } else {
+                Text("Open the app on a device to see \"Hello, world.\"")
+                    .multilineTextAlignment(.center)
+            }
         }
         .padding()
+        .onChange(of: scenePhase) { coordinator.updateForScenePhase($0) }
+        .onAppear { coordinator.updateForScenePhase(scenePhase) }
     }
 }
 

--- a/hearhear Watch App/DisplayCoordinator.swift
+++ b/hearhear Watch App/DisplayCoordinator.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Combine
+import WatchConnectivity
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
+
+final class DisplayCoordinator: NSObject, ObservableObject {
+    enum Device: String {
+        case phone
+        case watch
+    }
+
+    @Published private(set) var activeDevice: Device?
+    @Published private(set) var showMessage: Bool = false
+
+    private let localDevice: Device
+    private var isPhoneActive: Bool = false
+    private var isWatchActive: Bool = false
+    private var session: WCSession?
+
+    init(localDevice: Device) {
+        self.localDevice = localDevice
+        super.init()
+        configureSessionIfNeeded()
+        updateVisibility()
+    }
+
+    func setLocalActive(_ isActive: Bool) {
+        switch localDevice {
+        case .phone:
+            if isPhoneActive == isActive { return }
+            isPhoneActive = isActive
+        case .watch:
+            if isWatchActive == isActive { return }
+            isWatchActive = isActive
+        }
+        updateVisibility()
+        broadcastLocalState(isActive: isActive)
+    }
+
+    private func configureSessionIfNeeded() {
+        guard WCSession.isSupported() else { return }
+        let currentSession = WCSession.default
+        currentSession.delegate = self
+        currentSession.activate()
+        session = currentSession
+    }
+
+    private func broadcastLocalState(isActive: Bool) {
+        guard let session, session.activationState == .activated else { return }
+        let payload: [String: Any] = [
+            "source": localDevice.rawValue,
+            "isActive": isActive
+        ]
+        do {
+            try session.updateApplicationContext(payload)
+        } catch {
+            // Silently ignore failures; the counterpart will receive the next update.
+        }
+        if session.isReachable {
+            session.sendMessage(payload, replyHandler: nil, errorHandler: nil)
+        }
+    }
+
+    private func handleIncomingState(_ payload: [String: Any]) {
+        guard let sourceRaw = payload["source"] as? String,
+              let source = Device(rawValue: sourceRaw),
+              let isActive = payload["isActive"] as? Bool,
+              source != localDevice else { return }
+
+        switch source {
+        case .phone:
+            isPhoneActive = isActive
+        case .watch:
+            isWatchActive = isActive
+        }
+        updateVisibility()
+    }
+
+    private func updateVisibility() {
+        let newActiveDevice: Device?
+        if isPhoneActive {
+            newActiveDevice = .phone
+        } else if isWatchActive {
+            newActiveDevice = .watch
+        } else {
+            newActiveDevice = nil
+        }
+        let shouldShow = newActiveDevice == localDevice
+
+        if Thread.isMainThread {
+            activeDevice = newActiveDevice
+            showMessage = shouldShow
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.activeDevice = newActiveDevice
+                self?.showMessage = shouldShow
+            }
+        }
+    }
+}
+
+extension DisplayCoordinator: WCSessionDelegate {
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        let currentlyActive: Bool = {
+            switch localDevice {
+            case .phone:
+                return isPhoneActive
+            case .watch:
+                return isWatchActive
+            }
+        }()
+        if activationState == .activated {
+            broadcastLocalState(isActive: currentlyActive)
+        }
+    }
+
+    #if os(iOS)
+    func sessionDidBecomeInactive(_ session: WCSession) { }
+
+    func sessionDidDeactivate(_ session: WCSession) {
+        session.activate()
+    }
+    #endif
+
+    func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {
+        handleIncomingState(message)
+    }
+
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
+        handleIncomingState(applicationContext)
+    }
+}
+
+#if canImport(SwiftUI)
+extension DisplayCoordinator {
+    func updateForScenePhase(_ phase: ScenePhase) {
+        setLocalActive(phase == .active)
+    }
+}
+#endif

--- a/hearhear/ContentView.swift
+++ b/hearhear/ContentView.swift
@@ -8,14 +8,34 @@
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var coordinator = DisplayCoordinator(localDevice: .phone)
+    @Environment(\.scenePhase) private var scenePhase
+
     var body: some View {
-        VStack {
+        VStack(spacing: 24) {
             Image(systemName: "globe")
                 .imageScale(.large)
                 .foregroundStyle(.tint)
-            Text("Hello, world!")
+
+            Group {
+                if coordinator.showMessage {
+                    Text("Hello, world!")
+                        .font(.title2)
+                        .bold()
+                } else if coordinator.activeDevice == .watch {
+                    Text("\"Hello, world\" is showing on your Apple Watch.")
+                        .multilineTextAlignment(.center)
+                        .font(.headline)
+                } else {
+                    Text("Open the app on a device to see \"Hello, world.\"")
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .frame(maxWidth: .infinity)
         }
         .padding()
+        .onChange(of: scenePhase) { coordinator.updateForScenePhase($0) }
+        .onAppear { coordinator.updateForScenePhase(scenePhase) }
     }
 }
 

--- a/hearhear/DisplayCoordinator.swift
+++ b/hearhear/DisplayCoordinator.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Combine
+import WatchConnectivity
+#if canImport(SwiftUI)
+import SwiftUI
+#endif
+
+final class DisplayCoordinator: NSObject, ObservableObject {
+    enum Device: String {
+        case phone
+        case watch
+    }
+
+    @Published private(set) var activeDevice: Device?
+    @Published private(set) var showMessage: Bool = false
+
+    private let localDevice: Device
+    private var isPhoneActive: Bool = false
+    private var isWatchActive: Bool = false
+    private var session: WCSession?
+
+    init(localDevice: Device) {
+        self.localDevice = localDevice
+        super.init()
+        configureSessionIfNeeded()
+        updateVisibility()
+    }
+
+    func setLocalActive(_ isActive: Bool) {
+        switch localDevice {
+        case .phone:
+            if isPhoneActive == isActive { return }
+            isPhoneActive = isActive
+        case .watch:
+            if isWatchActive == isActive { return }
+            isWatchActive = isActive
+        }
+        updateVisibility()
+        broadcastLocalState(isActive: isActive)
+    }
+
+    private func configureSessionIfNeeded() {
+        guard WCSession.isSupported() else { return }
+        let currentSession = WCSession.default
+        currentSession.delegate = self
+        currentSession.activate()
+        session = currentSession
+    }
+
+    private func broadcastLocalState(isActive: Bool) {
+        guard let session, session.activationState == .activated else { return }
+        let payload: [String: Any] = [
+            "source": localDevice.rawValue,
+            "isActive": isActive
+        ]
+        do {
+            try session.updateApplicationContext(payload)
+        } catch {
+            // Silently ignore failures; the counterpart will receive the next update.
+        }
+        if session.isReachable {
+            session.sendMessage(payload, replyHandler: nil, errorHandler: nil)
+        }
+    }
+
+    private func handleIncomingState(_ payload: [String: Any]) {
+        guard let sourceRaw = payload["source"] as? String,
+              let source = Device(rawValue: sourceRaw),
+              let isActive = payload["isActive"] as? Bool,
+              source != localDevice else { return }
+
+        switch source {
+        case .phone:
+            isPhoneActive = isActive
+        case .watch:
+            isWatchActive = isActive
+        }
+        updateVisibility()
+    }
+
+    private func updateVisibility() {
+        let newActiveDevice: Device?
+        if isPhoneActive {
+            newActiveDevice = .phone
+        } else if isWatchActive {
+            newActiveDevice = .watch
+        } else {
+            newActiveDevice = nil
+        }
+        let shouldShow = newActiveDevice == localDevice
+
+        if Thread.isMainThread {
+            activeDevice = newActiveDevice
+            showMessage = shouldShow
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.activeDevice = newActiveDevice
+                self?.showMessage = shouldShow
+            }
+        }
+    }
+}
+
+extension DisplayCoordinator: WCSessionDelegate {
+    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
+        let currentlyActive: Bool = {
+            switch localDevice {
+            case .phone:
+                return isPhoneActive
+            case .watch:
+                return isWatchActive
+            }
+        }()
+        if activationState == .activated {
+            broadcastLocalState(isActive: currentlyActive)
+        }
+    }
+
+    #if os(iOS)
+    func sessionDidBecomeInactive(_ session: WCSession) { }
+
+    func sessionDidDeactivate(_ session: WCSession) {
+        session.activate()
+    }
+    #endif
+
+    func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {
+        handleIncomingState(message)
+    }
+
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
+        handleIncomingState(applicationContext)
+    }
+}
+
+#if canImport(SwiftUI)
+extension DisplayCoordinator {
+    func updateForScenePhase(_ phase: ScenePhase) {
+        setLocalActive(phase == .active)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add a shared display coordinator that uses WatchConnectivity to track which device should present the greeting
- update the iPhone view to only show “Hello, world” when it has priority and communicate status to the watch
- adjust the watch interface to defer to the iPhone when it is active while still showing the greeting when it is the only open app

## Testing
- not run (Xcode is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d223b1d8a883259adea7c661b87e5c