### PR TITLE
Display reachability status on watch and phone

### DIFF
--- a/hearhear Watch App/ContentView.swift
+++ b/hearhear Watch App/ContentView.swift
@@ -5,11 +5,12 @@
 //  Created by Erin Akarice on 9/16/25.
 //
 
+import Combine
 import SwiftUI
 import WatchConnectivity
 
 struct ContentView: View {
-    @StateObject private var viewModel = ReachabilityViewModel()
+    @StateObject private var viewModel = WatchReachabilityViewModel()
 
     var body: some View {
         VStack(spacing: 10) {
@@ -31,7 +32,7 @@ struct ContentView: View {
 }
 
 @MainActor
-final class ReachabilityViewModel: NSObject, ObservableObject, WCSessionDelegate {
+final class WatchReachabilityViewModel: NSObject, ObservableObject, WCSessionDelegate {
     enum Status: String {
         case reachable
         case unreachable
@@ -44,10 +45,15 @@ final class ReachabilityViewModel: NSObject, ObservableObject, WCSessionDelegate
     var statusColor: Color { status == .reachable ? .green : .red }
 
     private var session: WCSession?
+    private var reachabilityPolling: AnyCancellable?
 
     override init() {
         super.init()
         configureSession()
+    }
+
+    deinit {
+        reachabilityPolling?.cancel()
     }
 
     private func configureSession() {
@@ -57,64 +63,36 @@ final class ReachabilityViewModel: NSObject, ObservableObject, WCSessionDelegate
         self.session = session
         session.delegate = self
         session.activate()
-        refreshStatus(propagate: true)
+        updateStatus(using: session)
+        startReachabilityPollingIfNeeded()
     }
 
-    private func refreshStatus(propagate: Bool) {
-        guard let session else { return }
-        setStatus(session.isReachable ? .reachable : .unreachable, propagate: propagate)
-    }
+    private func updateStatus(using session: WCSession) {
+        let newStatus: Status = session.isReachable ? .reachable : .unreachable
 
-    private func setStatus(_ newStatus: Status, propagate: Bool) {
-        let oldStatus = status
-        if oldStatus != newStatus {
+        if newStatus != status {
             status = newStatus
         }
-
-        guard propagate, let session else { return }
-        sendStatus(newStatus, via: session)
     }
 
-    private func sendStatus(_ status: Status, via session: WCSession) {
-        let payload = ["status": status.rawValue]
+    private func startReachabilityPollingIfNeeded() {
+        guard reachabilityPolling == nil else { return }
 
-        if session.isReachable {
-            session.sendMessage(payload, replyHandler: nil) { [weak self] _ in
-                Task { @MainActor in
-                    self?.setStatus(.unreachable, propagate: false)
-                }
+        reachabilityPolling = Timer.publish(every: 2, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                guard let session = self?.session else { return }
+                self?.updateStatus(using: session)
             }
-        } else {
-            do {
-                try session.updateApplicationContext(payload)
-            } catch {
-                // Ignore context propagation errors; status will refresh on the next callback.
-            }
-        }
-    }
-
-    private func handleRemotePayload(_ payload: [String: Any]) {
-        guard let rawValue = payload["status"] as? String,
-              let remoteStatus = Status(rawValue: rawValue) else { return }
-
-        setStatus(remoteStatus, propagate: false)
     }
 
     // MARK: - WCSessionDelegate
 
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
-        refreshStatus(propagate: true)
+        updateStatus(using: session)
     }
 
     func sessionReachabilityDidChange(_ session: WCSession) {
-        refreshStatus(propagate: true)
-    }
-
-    func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {
-        handleRemotePayload(message)
-    }
-
-    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
-        handleRemotePayload(applicationContext)
+        updateStatus(using: session)
     }
 }

--- a/hearhear/ContentView.swift
+++ b/hearhear/ContentView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import WatchConnectivity
 
 struct ContentView: View {
-    @StateObject private var viewModel = ReachabilityViewModel()
+    @StateObject private var viewModel = PhoneReachabilityViewModel()
 
     var body: some View {
         VStack(spacing: 12) {
@@ -32,7 +32,7 @@ struct ContentView: View {
 }
 
 @MainActor
-final class ReachabilityViewModel: NSObject, ObservableObject, WCSessionDelegate {
+final class PhoneReachabilityViewModel: NSObject, ObservableObject, WCSessionDelegate {
     enum Status: String {
         case reachable
         case unreachable
@@ -58,65 +58,25 @@ final class ReachabilityViewModel: NSObject, ObservableObject, WCSessionDelegate
         self.session = session
         session.delegate = self
         session.activate()
-        refreshStatus(propagate: true)
+        updateStatus(using: session)
     }
 
-    private func refreshStatus(propagate: Bool) {
-        guard let session else { return }
-        setStatus(session.isReachable ? .reachable : .unreachable, propagate: propagate)
-    }
+    private func updateStatus(using session: WCSession) {
+        let newStatus: Status = session.isReachable ? .reachable : .unreachable
 
-    private func setStatus(_ newStatus: Status, propagate: Bool) {
-        let oldStatus = status
-        if oldStatus != newStatus {
+        if newStatus != status {
             status = newStatus
         }
-
-        guard propagate, let session else { return }
-        sendStatus(newStatus, via: session)
-    }
-
-    private func sendStatus(_ status: Status, via session: WCSession) {
-        let payload = ["status": status.rawValue]
-
-        if session.isReachable {
-            session.sendMessage(payload, replyHandler: nil) { [weak self] _ in
-                Task { @MainActor in
-                    self?.setStatus(.unreachable, propagate: false)
-                }
-            }
-        } else {
-            do {
-                try session.updateApplicationContext(payload)
-            } catch {
-                // Ignore context propagation errors; status will refresh on the next callback.
-            }
-        }
-    }
-
-    private func handleRemotePayload(_ payload: [String: Any]) {
-        guard let rawValue = payload["status"] as? String,
-              let remoteStatus = Status(rawValue: rawValue) else { return }
-
-        setStatus(remoteStatus, propagate: false)
     }
 
     // MARK: - WCSessionDelegate
 
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
-        refreshStatus(propagate: true)
+        updateStatus(using: session)
     }
 
     func sessionReachabilityDidChange(_ session: WCSession) {
-        refreshStatus(propagate: true)
-    }
-
-    func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {
-        handleRemotePayload(message)
-    }
-
-    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
-        handleRemotePayload(applicationContext)
+        updateStatus(using: session)
     }
 
 #if os(iOS)
@@ -124,10 +84,11 @@ final class ReachabilityViewModel: NSObject, ObservableObject, WCSessionDelegate
 
     func sessionDidDeactivate(_ session: WCSession) {
         session.activate()
+        updateStatus(using: session)
     }
 
     func sessionWatchStateDidChange(_ session: WCSession) {
-        refreshStatus(propagate: true)
+        updateStatus(using: session)
     }
 #endif
 }


### PR DESCRIPTION
## Summary
- show a reachability indicator on the iOS app using WatchConnectivity
- mirror the connection status on the watch app so both devices show reachable/unreachable

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d22574c95483258294f252e55c9b0b