### PR TITLE
Show connectivity status on phone and watch

### DIFF
--- a/hearhear Watch App/ContentView.swift
+++ b/hearhear Watch App/ContentView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Combine
 import WatchConnectivity
 
 struct ContentView: View {
@@ -27,21 +28,42 @@ struct ContentView: View {
 final class ConnectivityStatusProvider: NSObject, ObservableObject {
     @Published private(set) var isReachable = false
 
+    private var session: WCSession?
+    private var reachabilityPolling: AnyCancellable?
+
     override init() {
         super.init()
         activateSessionIfNeeded()
     }
 
+    deinit {
+        reachabilityPolling?.cancel()
+    }
+
     private func activateSessionIfNeeded() {
         guard WCSession.isSupported() else { return }
         let session = WCSession.default
+        self.session = session
         session.delegate = self
         session.activate()
         updateReachability(using: session)
+        startReachabilityPollingIfNeeded()
+    }
+
+    private func startReachabilityPollingIfNeeded() {
+#if os(watchOS)
+        guard reachabilityPolling == nil else { return }
+        reachabilityPolling = Timer.publish(every: 2, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                guard let session = self?.session else { return }
+                self?.updateReachability(using: session)
+            }
+#endif
     }
 
     private func updateReachability(using session: WCSession) {
-        let reachable = session.isReachable
+        let reachable = session.activationState == .activated && session.isReachable
         DispatchQueue.main.async { [weak self] in
             self?.isReachable = reachable
         }


### PR DESCRIPTION
## Summary
- display the counterpart reachability status in the iPhone and watch apps
- integrate a WatchConnectivity-based observable provider to keep the UI updated

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d322e35e288325b2fb6a5a6f385f73