### PR TITLE
Add speech detection to recorded chunks

### DIFF
--- a/hearhear/ContentView.swift
+++ b/hearhear/ContentView.swift
@@ -32,13 +32,18 @@ struct ContentView: View {
                         .font(.headline)
                     ScrollView {
                         VStack(alignment: .leading, spacing: 4) {
-                            ForEach(recorder.recordedChunks, id: \.self) { url in
-                                Text(url.lastPathComponent)
-                                    .font(.caption)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(8)
-                                    .background(Color(.secondarySystemBackground))
-                                    .cornerRadius(8)
+                            ForEach(recorder.recordedChunks) { chunk in
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(chunk.url.lastPathComponent)
+                                        .font(.caption)
+                                    Text(statusText(for: chunk))
+                                        .font(.caption2)
+                                        .foregroundColor(statusColor(for: chunk))
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(8)
+                                .background(Color(.secondarySystemBackground))
+                                .cornerRadius(8)
                             }
                         }
                     }
@@ -68,4 +73,28 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+}
+
+private extension ContentView {
+    func statusText(for chunk: RecordedChunk) -> String {
+        switch chunk.hasSpeech {
+        case true:
+            return "Speech detected"
+        case false:
+            return "No speech detected"
+        case nil:
+            return "Analyzing for speech..."
+        }
+    }
+
+    func statusColor(for chunk: RecordedChunk) -> Color {
+        switch chunk.hasSpeech {
+        case true:
+            return Color.green
+        case false:
+            return Color.secondary
+        case nil:
+            return Color.orange
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- introduce a `RecordedChunk` model that stores URLs alongside optional speech classification results
- classify each recorded file with the built-in SoundAnalysis speech classifier and update chunk metadata
- surface the speech detection status in the recorded chunk list within the SwiftUI view

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d379aef3c4832582718ec66fe57152